### PR TITLE
fix crash when the message contains no payload

### DIFF
--- a/src/monitor.js
+++ b/src/monitor.js
@@ -9,11 +9,18 @@ export default async function monitor({ port, address }) {
 
     socket.on('message', buffer => {
       const message = osc.fromBuffer(buffer)
-      console.log(
-        `${`[${port}]`.gray} ${message.address.padEnd(30).yellow} ${colors.cyan(
-          message.args[0].value
-        )} (${message.args[0].type.white})`
-      )
+      if (message.args[0]) {
+        console.log(
+          `${`[${port}]`.gray} ${message.address.padEnd(30).yellow} ${colors.cyan(
+            message.args[0].value
+          )} (${message.args[0].type.white})`
+        )
+      } else {
+        // no payload
+        console.log(
+          `${`[${port}]`.gray} ${message.address.padEnd(30).yellow} (${"null".white})`
+        )
+      }
     })
 
     console.log(`Now go send some OSC messages to this address...`.gray)

--- a/src/send.js
+++ b/src/send.js
@@ -72,7 +72,7 @@ export default async function send({ port, address = null }) {
       const value = parseInputValue(rawValue)
       const message = osc.toBuffer({
         address: oscAddress,
-        args: [value],
+        args: Number.isNaN(value) ? [] : [value],
       })
       await sendMessage(socket, message, port, receiverIp)
     }


### PR DESCRIPTION
This tool currently crashes when it receives an OSC message with no payload. This pull request fixes the bug.

This PR also allows the sender to send messages with no payload. Currently, it just sends a payload of `NaN` instead of nothing.